### PR TITLE
docs(handoff): 2026-04-07 session handoff

### DIFF
--- a/docs/audits/2026-04-07-session-handoff.md
+++ b/docs/audits/2026-04-07-session-handoff.md
@@ -1,0 +1,184 @@
+# 2026-04-07 Session Handoff
+
+## Last commit on main at handoff time
+
+`43814f8 Merge pull request #27 from nullvoidundefined/chore/eng-22-cleanup-2026-04-07`
+
+## Production state verified
+
+- `https://server-production-f028.up.railway.app/health`: **200** `{"status":"ok"}`
+- `https://interviewiangreenough.xyz/`: **200**
+- GitHub Actions latest 3 runs (PR #27 merge): CI ✓, Post-Deploy Health Check ✓, E2E ✓
+- Vercel: deployment complete
+
+All four surfaces are green.
+
+## What shipped today
+
+Grouped by topic, not by commit order. Every item is traceable to a commit SHA or file path.
+
+### Six user-reported bug fixes (PR #24)
+
+Branch: `fix/bug-batch-2026-04-07`. Spec at `docs/superpowers/specs/2026-04-07-bug-fix-batch-design.md`. Plan at `docs/superpowers/plans/2026-04-07-bug-fix-batch.md`. Merged via PR #24 (`e6352a1`).
+
+- **B1 / B24** (`3b50361`, P1): Trip detail Budget tile and Cost Breakdown rendered `$NaN`. Root cause: `pg` returned NUMERIC columns as JavaScript strings, and the trip detail page reduced over `c.total_price` without a defensive default. Fix: registered a global `pg.types.setTypeParser` for the NUMERIC OID in `server/src/db/pool/pool.ts`, plus `?? 0` and `Number.isFinite` guards in `web-client/src/app/(protected)/trips/[id]/page.tsx`. Tests in `server/src/db/pool/pool.test.ts` and `web-client/src/app/(protected)/trips/[id]/page.test.tsx`. Test fixture uses `Number.NaN` (not `null`) because `0 + null === 0` in JavaScript and would not have produced a failing test.
+
+- **B2 / B25** (`d8c363a`, P1): Car rental tool threw on SerpApi errors and the agent improvised "having trouble accessing." Root cause: `searchCarRentals` did not catch SerpApi errors, so any upstream failure threw to the executor. Fix: wrap the SerpApi call in try/catch and return `{ rentals: [], error }` instead. Updated `server/src/tools/definitions.ts` so the agent narrates "no car rentals available for this destination" instead of improvising. Three new tests in `server/src/tools/car-rentals.tool.test.ts`.
+
+- **B3 / B26** (`990b30c`, P2): Tool progress chips had no horizontal gap and duplicated "Done" labels. Fix: replaced the per-tool `ToolProgressIndicator` chips with a single consolidated `ChatProgressBar` widget that collapses adjacent `tool_progress` nodes into one determinate progress bar. New invariant 6 in `web-client/src/components/ChatBox/ChatBox.invariants.test.tsx` locks the "exactly one progressbar" guarantee. Old chip files deleted.
+
+- **B4 / B27** (`6bfa8b4`, P2): Chat appeared dead between user submit and the first SSE chunk. Fix: render an indeterminate `ChatProgressBar` with the label "Thinking" while `isSending` is true and no streaming nodes have arrived yet. Implementation extends the B3 widget with an indeterminate mode. New invariant 7 locks the synchronous-render-and-disappear-on-first-event behavior. The render condition has a fifth guard (`messages.at(-1)?.role !== 'assistant'`) added to preserve invariant 6 (the implementer caught and fixed this regression mid-task).
+
+- **B5 / B28** (`029e2e7`, `d43f929`, `f819b46`, P3): No vertical gap between the chat box and the Flights heading. Fix: 48px `margin-bottom` on `.chatSection` plus matching `margin-top` on `.itinerary` in `web-client/src/app/(protected)/trips/[id]/tripDetail.module.scss`. Playwright spec at `e2e/trip-page-spacing.spec.ts` asserts `gap >= 32` via `getBoundingClientRect`. The original commit also shipped a visual snapshot, but it was darwin-only and would have broken Linux CI; the two `chore(B5)` follow-up commits dropped the snapshot and kept the computed-style assertion.
+
+- **B6 / B29** (`c264b75`, P2): Huge "Book This Trip" / "Try Again" buttons replaced with an inline `BookingPrompt` tile rendered as the last assistant message in the chat stream. New `booking_prompt` virtual node type in `packages/shared-types/src/nodes.ts` (client-only, never persisted). Conditional chips show only what is missing from the trip (`Book now` always, `Add experiences` if empty, `Add car rental` if empty, `Change something` always). New invariant 8 locks the inline render path. Old `bookingActions`/`bookButton`/`tryAgainButton` blocks deleted.
+
+### Two follow-up fixes for sibling tools (PR #25)
+
+Branch: `chore/bug-batch-followups-2026-04-07`. Surfaced during the B25 review when the reviewer noted that `flights.tool.ts` and `hotels.tool.ts` had the same latent failure mode B25 fixed for car rentals. Merged via PR #25 (`703796a`).
+
+- **B7 / B30** (`0ffbcec`, P2): `searchFlights` only caught `SerpApiQuotaExceededError` and re-threw all other errors. Fix: extend the catch block to log at warn and return `[]` for any error, preserving the existing return type. Replaced a pre-existing `'handles API errors gracefully'` test that asserted `.rejects.toThrow(...)` because it directly contradicted the new fail-soft contract.
+
+- **B8 / B31** (`bfb8cc9`, P2): Same fix for `searchHotels`. Replaced an equivalent contradictory `'rethrows non-quota errors'` test.
+
+### Two doc updates (PR #25)
+
+- **`886cc22` `docs(meta):`** Updated Voyager `CLAUDE.md` to acknowledge that GitHub branch protection on `main` requires the `e2e` status check as of 2026-04-07. The "trunk-based, 0 PRs, 0 merge commits in the first 246 commits" claim is no longer accurate. The lefthook pre-push hook is still valuable as a fast local gate but is no longer the only code-review boundary; the CI `e2e` check is now the authoritative gate.
+
+- **`d4e23ff` `docs(BUGS):`** Renumbered the 2026-04-07 fix-batch IDs in `docs/bugs.md` from B1-B6 to B24-B29 to eliminate the numerical collision with the historical B1-B23 entries already in the file. Added B30 and B31 entries for the follow-ups. The shipped commit subjects on main still say `fix(B1)` through `fix(B6)` (history is immutable); only the docs log moves to the new IDs. Updated `docs/audits/2026-04-07-triage.md` to match.
+
+### Three triage cleanups (PRs #26 and #27)
+
+- **`0953f23` `chore(ENG-20):`** All 13 worktrees in `.claude/worktrees/` from the 2026-04-06 audit work removed, plus their 13 branches plus one bonus orphan branch (`worktree-agent-aebc5a93`). Each branch was triaged before deletion. 4 were already-merged ancestors of main; 8 audit branches contained one report file each that already existed on main with only formatting cleanups landed during the original audit pass; 1 was the docs/billing branch whose change had shipped via PR #21. No content was lost. ISSUES.md updated to RESOLVED.
+
+- **`63e71f8` `chore(ENG-21):`** ENG-21 marked RESOLVED as bookkeeping only. Verified that `CLAUDE.md` actually contained 0 em dashes (U+2014) at every commit from `5380f99` onwards. The 8 em dashes ENG-21 referenced existed at `27e41de` and `c2a3bc2` but had been removed before ENG-21 was even logged at `22dda36`. The original ticket apparently transposed line numbers from an earlier inspection of an older revision.
+
+- **`f00157b` `chore(ENG-22):`** All 12 stale local branches without worktrees from the 2026-04-06 era removed. 11 were already-merged ancestors of main (label-only leftovers). The remaining `backup/pre-reset-2026-04-07` had 5 unique commits representing the pre-rebase form of the eslint-ignore, lefthook-staged-files, ENG-20-ticket, CLAUDE.md-incident-history, and 4-doc-prettier work; verified the resulting content is on main via grep. No content lost. ISSUES.md updated to RESOLVED.
+
+## Today's session in numbers
+
+- 4 PRs merged: #24 (six bug fixes), #25 (two follow-up fixes plus docs), #26 (ENG-20/21 cleanup), #27 (ENG-22 cleanup)
+- 19 commits on main across the four PRs
+- 6 production bugs fixed (B24-B29)
+- 2 latent failure modes patched (B30, B31)
+- 3 ENG triage items resolved (ENG-20, ENG-21, ENG-22)
+- 26 git refs cleaned up: 13 worktrees, 14 stale branches (13 worktree branches + 1 orphan + 12 standalone), with the auto-deletion via `gh pr merge` removing 4 feature branches
+- 0 production deploys broken
+- 0 em dashes introduced
+- 0 hook bypasses, 0 `--no-verify` uses
+- 8 ChatBox invariants now locked by `ChatBox.invariants.test.tsx` (was 5 at session start; B3, B4, B6 each added one)
+
+## What is currently pending
+
+### Blockers / urgent
+
+None. Production is green. No P0 or P1 items in the open backlog after today's work.
+
+### High-value next-up (P2)
+
+These are the highest-impact items from `ISSUES.md` that remain open. None is blocking production but each is meaningful pre-launch hardening.
+
+- **ENG-05** P2 / M: No Sentry / error tracking integrated. A multi-step agent loop without error tracking is guesswork during incidents. Add Sentry to both server and web-client. The deploy infrastructure has logs and post-deploy health checks; Sentry adds the observability layer that lets you triage by error rather than wait for a user report.
+
+- **ENG-06** P2 / L: No `pnpm audit` in CI, no Dependabot / Renovate. A repo with ~40 dependencies and no automated dependency updates will drift into CVEs within 6-12 months. Add `pnpm audit --prod` to CI, configure `.github/dependabot.yml`. The L is mostly the audit-noise triage on first run.
+
+- **ENG-07** P2 / M: Chat endpoint has no integration test. SSE flow, auth, rate limit, 409 conflict under lock. The critical-path endpoint has only unit tests. The integration-test infrastructure exists in `server/src/__integration__/`; this is just adding the missing spec.
+
+- **ENG-08** P2 / S: Dockerfile runs as root. Add `USER node`. Cheapest pre-launch security win.
+
+- **ENG-09** P2 / S: Smoke test script not wired to CI. Verify `scripts/smoke-test.sh` exists and add it to the CI workflow.
+
+### Lower-priority (P3)
+
+- **ENG-19**: Push server vitest coverage threshold from 80 to 85. Already RESOLVED in PR-K but the ENG-19 line in ISSUES.md still references the original threshold; cosmetic cleanup.
+- **ENG-16**: Worktree pre-push e2e fast-lane needs `server/.env`. Hit twice today during PR #24 and PR #25. A `chore` that auto-symlinks during worktree provisioning would prevent it. Low priority because new worktrees are now rare after ENG-20.
+- **CRIT-XX** items in `docs/audits/2026-04-06-criticism.md`. Not pulled into this session.
+
+### Surfaced during reviews but not yet logged
+
+These are observations the code-quality reviewers made during PR #24 / PR #25 that did not warrant blocking the PRs but should be tracked for follow-up.
+
+- **`VirtualizedChat.tsx:99` unused eslint-disable directive.** Pre-existing warning, not introduced today. Cheap cleanup commit when next touching that file.
+- **`VirtualizedChat.tsx:39` `NODE_HEIGHT_ESTIMATES['tool_progress'] = 32` is now dead.** Since B3, the renderer returns null for `tool_progress` and the partition pulls these nodes out of the per-node mapping path. The 32px estimate inflates the virtualizer's height guess for any message that contains tool_progress nodes. Drop the entry or set to 0.
+- **`ChatProgressBar.module.scss` indeterminate animation animates `left`, not `transform`.** Triggers layout on every frame. `transform: translateX(...)` is GPU-composited and would not re-layout the document. Performance-only.
+- **`docs/bugs.md` filename case is lowercase but `CLAUDE.md` references it as `docs/BUGS.md`.** macOS case-insensitivity hides this. Worth a one-line CLAUDE.md correction.
+- **Root `pnpm test` only runs server tests.** Web-client tests (now 89) need a separate `pnpm --filter voyager-web test` invocation. Worth aliasing the root script to recurse, or documenting the split.
+
+## Recommended next session
+
+Pick whichever fits the available time. Items are independent enough that any subset works.
+
+### Option A: Polish session (1 to 2 hours)
+
+If the next session is short, knock out the low-hanging cleanups surfaced during reviews:
+
+1. Drop or zero out `NODE_HEIGHT_ESTIMATES['tool_progress']` in `web-client/src/components/ChatBox/VirtualizedChat.tsx:39`. Single commit.
+2. Remove the unused eslint-disable at `web-client/src/components/ChatBox/VirtualizedChat.tsx:99`. Single commit.
+3. Switch `ChatProgressBar` indeterminate animation from `left` to `transform: translateX(...)`. Single commit.
+4. Fix the `docs/BUGS.md` vs `docs/bugs.md` case mismatch in `CLAUDE.md`. Single commit.
+5. Alias root `pnpm test` to run web-client tests too. Single commit.
+
+All five would fit in one PR.
+
+### Option B: Pre-launch hardening (one full session)
+
+If the next session is longer and you want meaningful progress on launch readiness, work the P2 backlog in this order:
+
+1. **ENG-08** Dockerfile USER node. Smallest. Single commit, single line change, no test required (it is a Dockerfile-only edit). Use it as a session warmup.
+2. **ENG-09** Smoke test script wired to CI. Verify `scripts/smoke-test.sh` exists; if not, write it; then add it to `.github/workflows/ci.yml`. Single PR.
+3. **ENG-07** Chat endpoint integration test. Use the existing `server/src/__integration__/` infrastructure. Cover: auth required, rate limit, 409 lock conflict, SSE happy path. Test-first per the global rule.
+4. **ENG-05** Sentry integration. The medium-effort one. Server: `@sentry/node` plus error middleware. Web-client: `@sentry/nextjs` plus error boundary. Configure DSN via env vars; add to Railway and Vercel. Verify a deliberate error reaches Sentry before considering it done.
+5. **ENG-06** pnpm audit and Dependabot. Save for last; the audit will surface a list of CVEs and you do not want to be triaging them under time pressure.
+
+### Option C: Strategic / Criticism
+
+If the next session is for strategic review rather than coding, the Criticism audit role should run against today's work. Today we shipped 6 bug fixes and 2 follow-up fixes, but did not run any of the eight audit roles. The Criticism audit specifically should evaluate whether today's fixes are addressing symptoms or root causes, and whether the time spent on the cleanup commits (ENG-20/21/22, three PRs) was well-allocated relative to the engineering backlog.
+
+## Files to read first in the next session
+
+These are the files the next session will most likely need to load. Pre-loading them keeps the next session's context budget on the actual work.
+
+- `docs/audits/2026-04-07-session-handoff.md` (this file)
+- `ISSUES.md` (open backlog with severity tags)
+- `docs/bugs.md` (resolved bug log; B30/B31 are the most recent entries)
+- `docs/audits/2026-04-07-triage.md` (P1 mirror)
+- `CLAUDE.md` (project conventions, recently updated to reflect PR-required workflow)
+- `docs/superpowers/specs/2026-04-07-bug-fix-batch-design.md` (today's spec, useful as a reference for what the brainstorm-spec-plan-implement loop produced)
+- `docs/superpowers/plans/2026-04-07-bug-fix-batch.md` (today's plan)
+- `docs/audits/2026-04-06-process-retrospective.md` (the source of the test-first, no-batching, hook-verification rules that shaped today's work)
+
+## Workflow reminders
+
+The next session must follow these rules. They are codified in `~/.claude/CLAUDE.md` and Voyager's `CLAUDE.md`, but listing them here keeps the load-bearing ones front-of-mind.
+
+- **PR-required workflow.** Direct push to main fails with `GH013: Required status check "e2e" is expected`. Push the feature branch, open a PR via `gh pr create`, wait for CI (`gh pr checks <num>`), merge with `gh pr merge --merge --delete-branch`. Pre-push hook is still valuable as a fast local gate but is no longer the only code-review boundary.
+- **Test-first for every `fix:` commit.** Write the failing test, run it, confirm RED, then write the fix, run again, confirm GREEN, run full verification chain, commit. The fix-commit-gate hook blocks any `fix:` subject without a test file in the same commit. Never use `--no-verify` to bypass without explicit per-commit user authorization.
+- **One commit per bug ID.** Never batch unrelated bug IDs into a single commit.
+- **No em dashes (U+2014).** Use period and new sentence, comma, semicolon, colon, parentheses, or line break depending on context. Hyphens and en dashes are fine. The global rule covers conversations, code, comments, commit messages, markdown, and prompts to subagents.
+- **No `pnpm test` only.** Root `pnpm test` runs only server tests. The web-client suite must be invoked separately as `pnpm --filter voyager-web test` until ENG-22-followup-1 (the test-runner alias) lands.
+- **Worktree provisioning needs `server/.env`.** The pre-push e2e fast lane fails on a fresh worktree because worktrees do not inherit `.env` files. Symlink it manually: `ln -sf /Users/iangreenough/Desktop/code/personal/production/voyager/server/.env server/.env`. Pinned in ISSUES.md as ENG-16.
+- **`docs/bugs.md` filename is lowercase.** macOS case-insensitivity hides this; CLAUDE.md still references the uppercase form. Worth fixing in a future commit.
+- **Audits write to `docs/audits/YYYY-MM-DD-<role>.md`.** Never overwrite a prior audit. Today produced one new audit doc (`2026-04-07-triage.md`).
+- **Severity tagging on every `docs/bugs.md` entry.** First line must contain `severity: P0|P1|P2|P3` and `effort: S|M|L`. P0 and P1 entries get mirrored into the current `docs/audits/YYYY-MM-DD-triage.md`.
+- **Estimation discipline.** Ian ships afternoon-scale work in afternoons. Divide prior estimates by 3x to 5x before surfacing a number. Today's session validated this: the brainstorm-spec-plan-implement loop for six bugs plus two follow-ups plus three cleanup PRs all landed in one continuous afternoon session.
+
+## Companion docs
+
+Linked from this handoff so the dependency graph is explicit.
+
+- **Spec:** `docs/superpowers/specs/2026-04-07-bug-fix-batch-design.md`
+- **Plan:** `docs/superpowers/plans/2026-04-07-bug-fix-batch.md`
+- **Triage:** `docs/audits/2026-04-07-triage.md`
+- **Bug log:** `docs/bugs.md` (B24-B31 are today's entries)
+- **Open backlog:** `ISSUES.md` (ENG-05, ENG-06, ENG-07, ENG-08, ENG-09 are the next P2 items)
+- **Process retrospective that shaped today's discipline:** `docs/audits/2026-04-06-process-retrospective.md`
+- **Project conventions:** `CLAUDE.md` (recently updated for PR workflow)
+- **Global rules:** `~/.claude/CLAUDE.md` (test-first, em-dash ban, severity tagging, audit history conventions)
+
+## TODO updates pending
+
+Items in project task files that should be touched during the next session's opening moves.
+
+- `TODO_BEFORE_LAUNCH.md` (if it exists; was not opened during today's session): mark any items already addressed by today's bug fixes. Today's B24-B31 closed real production issues, some of which may be referenced there.
+- `ISSUES.md` ENG-19: line still says "RESOLVED in PR-K" but the underlying threshold push to 85 may have been done in a different PR; verify and clean up the prose.
+- `ISSUES.md` ENG-22-followup placeholders: surfaced during reviews. Worth a single chore PR with five small commits (see "Option A" above).


### PR DESCRIPTION
## Summary

Per the global "offer a session handoff doc when wrapping up" rule. Captures what shipped today across PRs #24-27, what is currently pending, and the recommended next-session task ordering.

The next session should read this file first before opening ISSUES.md or doing any work.

## Sections

- Last commit on main at handoff time
- Production state verified (all four surfaces)
- What shipped today (grouped by PR / topic)
- Today's session in numbers
- What is currently pending (blockers, P2 next-up, P3, surfaced-during-reviews)
- Recommended next session (three options: polish, hardening, criticism)
- Files to read first
- Workflow reminders
- Companion docs
- TODO updates pending

## Test plan

- [x] Em dash scan: 0 in the handoff doc
- [x] Format check clean
- [x] All references to commit SHAs verified against \`git log\`
- [x] All references to PR numbers verified
- [x] Production state probed at write time

🤖 Generated with [Claude Code](https://claude.com/claude-code)