### PR TITLE
refactor(tools): drop the unused toolSchemas export

### DIFF
--- a/apps/server/src/tools/schemas.ts
+++ b/apps/server/src/tools/schemas.ts
@@ -1,12 +1,8 @@
 /**
- * Tool input schemas. The per-tool Zod schemas now live beside their definitions
- * in tools/registry/; this module re-exports them under their established names
- * (so executor imports stay stable). It also exports a name->schema map derived
- * from the registry.
+ * Tool input schemas. The per-tool Zod schemas live beside their definitions in
+ * tools/registry/; this module re-exports them under their established names so
+ * the executor's imports stay stable.
  */
-import { TOOL_REGISTRY } from 'app/tools/registry/toolRegistry.js';
-import type { ZodType } from 'zod';
-
 export { addLegSchema } from 'app/tools/registry/addLeg.js';
 export { calculateBudgetSchema } from 'app/tools/registry/calculateRemainingBudget.js';
 export { formatResponseSchema } from 'app/tools/registry/formatResponse.js';
@@ -24,7 +20,3 @@ export { selectExperienceSchema } from 'app/tools/registry/selectExperience.js';
 export { selectFlightSchema } from 'app/tools/registry/selectFlight.js';
 export { selectHotelSchema } from 'app/tools/registry/selectHotel.js';
 export { updateTripSchema } from 'app/tools/registry/updateTrip.js';
-
-export const toolSchemas: Record<string, ZodType> = Object.fromEntries(
-  TOOL_REGISTRY.map((tool) => [tool.name, tool.schema]),
-);

--- a/docs/prs/2026-06-15-drop-unused-toolschemas.md
+++ b/docs/prs/2026-06-15-drop-unused-toolschemas.md
@@ -1,0 +1,48 @@
+# PR: Drop the unused `toolSchemas` export
+
+Branch: `refactor/drop-unused-toolschemas`, off `main`.
+Date: 2026-06-15. Time since implementation: same session.
+
+## Summary
+
+Follow-up to the tool-registry refactor (#43). Removes the dead `toolSchemas`
+name->schema map from `tools/schemas.ts`. Its only consumer was the old
+`schemaDrift.test.ts`, which #43 deleted (the derivation test replaced it), so the export
+has had no references since. `tools/schemas.ts` becomes a pure re-export barrel of the 17
+named per-tool schemas, which is all `executor.ts` actually imports.
+
+Resolves the Copilot review finding on #43 (the module comment described `toolSchemas` as
+the validation-dispatch surface, but nothing referenced it). The merged auto-fix corrected
+the comment; this removes the export the comment was describing.
+
+## What changed
+
+- `tools/schemas.ts`: deleted the `toolSchemas` const and its now-unused `TOOL_REGISTRY`
+  and `ZodType` imports. The file is now only the 17 `export { xSchema } from registry`
+  re-exports.
+
+## Decision: delete vs. wire into the executor
+
+The alternative was to make `toolSchemas` live by routing the executor's validation through
+it (`toolSchemas[name].safeParse(input)`). Rejected: `toolSchemas` is typed
+`Record<string, ZodType>`, so a generic lookup returns `unknown` and would force an `as`
+cast in all 17 executor cases. The current per-case `parseInput(name, namedSchema, input)`
+yields a precisely-typed `parsed.data` that flows into each typed adapter call. Per-case
+validation already fulfills the canonical pattern's contract ("safeParse the input against
+the tool's Zod schema") with better type safety, so the generic lookup is unnecessary.
+
+Note: the cross-repo `agentic-chat-pattern.md` lists a `toolSchemas` lookup as part of the
+standard. Voyager validates per-case instead; the lookup is optional for an executor that
+already dispatches type-safely. (Not updating the doc here to keep this PR single-scope.)
+
+## Testing
+
+- `tsc --noEmit`: clean (confirms nothing referenced the removed export).
+- `vitest run src/tools`: 452 passed.
+- `eslint src/tools/schemas.ts`: clean.
+
+## Reflection
+
+Small, but the right close-out: a derived registry made the parallel `toolSchemas` map
+redundant, and carrying a dead export "because the pattern doc mentions it" is the kind of
+speculative surface the export-hygiene rule exists to prevent.

--- a/docs/prs/2026-06-15-drop-unused-toolschemas.md
+++ b/docs/prs/2026-06-15-drop-unused-toolschemas.md
@@ -38,8 +38,8 @@ already dispatches type-safely. (Not updating the doc here to keep this PR singl
 ## Testing
 
 - `tsc --noEmit`: clean (confirms nothing referenced the removed export).
-- `vitest run src/tools`: 452 passed.
-- `eslint src/tools/schemas.ts`: clean.
+- `vitest run src/tools` (from `apps/server`): 452 passed.
+- `eslint src/tools/schemas.ts` (from `apps/server`): clean.
 
 ## Reflection
 

--- a/docs/prs/2026-06-15-drop-unused-toolschemas.md
+++ b/docs/prs/2026-06-15-drop-unused-toolschemas.md
@@ -8,7 +8,7 @@ Date: 2026-06-15. Time since implementation: same session.
 Follow-up to the tool-registry refactor (#43). Removes the dead `toolSchemas`
 name->schema map from `tools/schemas.ts`. Its only consumer was the old
 `schemaDrift.test.ts`, which #43 deleted (the derivation test replaced it), so the export
-has had no references since. `tools/schemas.ts` becomes a pure re-export barrel of the 17
+has had no code references since. `tools/schemas.ts` becomes a pure re-export barrel of the 17
 named per-tool schemas, which is all `executor.ts` actually imports.
 
 Resolves the Copilot review finding on #43 (the module comment described `toolSchemas` as


### PR DESCRIPTION
Follow-up to #43. Removes the dead `toolSchemas` name->schema map from `tools/schemas.ts`. Its only consumer was the `schemaDrift.test.ts` that #43 deleted, so nothing has referenced it since. `schemas.ts` becomes a pure re-export barrel of the 17 named per-tool schemas (all `executor.ts` imports).

Resolves the Copilot finding on #43 (the comment described `toolSchemas` as the validation-dispatch surface; nothing used it). The merged auto-fix corrected the comment; this removes the export.

**Why delete rather than wire it into the executor:** `toolSchemas` is `Record<string, ZodType>`, so a generic `toolSchemas[name].safeParse()` returns `unknown` and would force an `as` cast in all 17 executor cases. The current per-case `parseInput(name, namedSchema, input)` keeps precise types flowing into each adapter and already satisfies the pattern's "validate against the tool's Zod schema" contract.

## Testing
- `tsc --noEmit` clean (confirms zero references to the removed export)
- `vitest run src/tools`: 452 passed
- `eslint` clean

Full writeup: `docs/prs/2026-06-15-drop-unused-toolschemas.md`