### PR TITLE
fix(models): use current claude-sonnet-4-6 default model id

### DIFF
--- a/apps/server/src/__tests__/constants/models.test.ts
+++ b/apps/server/src/__tests__/constants/models.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_MODEL } from 'app/constants/models.js';
+
+describe('DEFAULT_MODEL', () => {
+  it('uses the current claude-sonnet-4-6 id, not the retired sonnet-4 snapshot', () => {
+    expect(DEFAULT_MODEL).toBe('claude-sonnet-4-6');
+  });
+});

--- a/apps/server/src/constants/models.ts
+++ b/apps/server/src/constants/models.ts
@@ -4,4 +4,4 @@
  * and so a model bump is a one-line change in a single place.
  */
 export const DEFAULT_MAX_TOKENS = 2048;
-export const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+export const DEFAULT_MODEL = 'claude-sonnet-4-6';


### PR DESCRIPTION
`DEFAULT_MODEL` was the retired Anthropic id `claude-sonnet-4-20250514`, which returns `404 not_found_error`. The agent orchestrator falls back to this id (`AgentOrchestrator` `config.model ?? DEFAULT_MODEL`), so any agent call without an explicit model would 404. Same class of bug as the policy-pilot and Doppelscript fixes.

## Fix
- `apps/server/src/constants/models.ts`: `DEFAULT_MODEL` `claude-sonnet-4-20250514` to `claude-sonnet-4-6` (the migration guide's drop-in replacement for the retired id).

## Test (R-201, test-first)
Added `src/__tests__/constants/models.test.ts` asserting `DEFAULT_MODEL === 'claude-sonnet-4-6'` (regression guard for the stale-id class). Confirmed RED on the old id, GREEN after the fix.

- `pnpm --filter voyager-server test`: 1107 passing
- `pnpm --filter voyager-server build`: clean

Note: the `__fixtures__/mockAnthropicClient` test fixtures still reference the old id as inert mock data (not a live API call, exempt test literals per R-219); left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)