### PR TITLE
fix(e2e): repair production smoke trips-shell selector

### DIFF
--- a/e2e/production/smoke.spec.ts
+++ b/e2e/production/smoke.spec.ts
@@ -101,9 +101,8 @@ test.describe('authenticated smoke', () => {
     await login(page, { email: SMOKE_EMAIL, password: SMOKE_PASSWORD });
     await expect(
       page
-        .locator(
-          'a:has-text("New Trip"), button:has-text("New Trip"), a:has-text("New trip"), button:has-text("New trip"), text=/No trips yet/i',
-        )
+        .locator('a:has-text("New Trip"), button:has-text("New Trip")')
+        .or(page.getByText(/No trips yet/i))
         .first(),
     ).toBeVisible({ timeout: 10_000 });
     await logout(page);


### PR DESCRIPTION
The production Post-Deploy Health Check has been red on the last several merges. One of its two failing smoke tests fails on a malformed Playwright locator.

## Fix
`e2e/production/smoke.spec.ts` (the "trips page renders content shell" test) passed a selector string that mixed Playwright's `text=` engine into a CSS selector list (`...text=/No trips yet/i`). Playwright parses the whole string as CSS and throws `Unexpected token "=" while parsing css selector`. Replaced with the documented API: `.locator('a:has-text("New Trip"), button:has-text("New Trip")').or(page.getByText(/No trips yet/i))`. (`:has-text` is already case-insensitive, so the redundant lowercase variants were dropped.)

## The other failing test
The second failure ("agent turn: trip creation and tile response") timed out waiting for a tile because the agent was calling the retired model id `claude-sonnet-4-20250514` (404). That root cause was fixed and deployed in #52 (`DEFAULT_MODEL` to `claude-sonnet-4-6`), so that test should pass once prod runs the new model.

## Verification
- `playwright test --config playwright.production.config.ts --list`: spec compiles and collects (12 tests).
- The authenticated smoke tests require `SMOKE_USER_*` secrets (CI-only), so full validation is the Post-Deploy Health Check on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)