### PR TITLE
fix(#60): stop production smoke from depending on live SerpApi

### DIFF
--- a/docs/prs/2026-06-25-prod-smoke-mock-serpapi.md
+++ b/docs/prs/2026-06-25-prod-smoke-mock-serpapi.md
@@ -1,0 +1,36 @@
+# Stop the production smoke from depending on live SerpApi (#60)
+
+**Date:** 2026-06-25
+**Branch:** `fix/prod-smoke-mock-serpapi`
+**Closes:** #60
+
+## Summary
+
+The Post-Deploy Health Check workflow failed on every run for days. The `health-check` job passed; the `e2e-production` job failed. Root cause: `e2e/production/smoke.spec.ts` had an `agent turn: trip creation and tile response` test that, against the **live** deployment, drove the agent and waited 120s for a real flight/hotel tile to render. That depends on live SerpApi results, and SerpApi's free tier is 250 searches/month, burned on every deploy. So the gate flaked on quota/agent timing, not on any code regression.
+
+This also violated `playwright.production.config.ts`'s own stated contract ("public pages, no auth, no agent calls, zero API cost").
+
+## What changed
+
+- **Removed the live-SerpApi `creation-and-tile-response` test** from the production smoke. Its deterministic equivalent already exists in the mocked e2e lane: `e2e/chat-booking-flow.spec.ts` US-22 asserts `[data-tile-card="flight"]` / `[data-tile-card="hotel"]` under `E2E_MOCK_TOOLS=1`, where flight/hotel results are mocked. The tile-card assertion is therefore still covered, against mocked SerpApi, just not against live quota.
+- **Trimmed `trip persists across sessions`** to not send an agent message. Persistence is established by `POST /trips`, and the test keys its list assertion off the created `tripId`, so it never needed to drive a live search.
+- **Updated the config doc comment** (per request): the production smoke has moved beyond public pages. It now documents that the lane covers public pages plus authenticated reachability and trip persistence, and deliberately does not drive live agent search (that lives, mocked, in the fast lane).
+
+Net effect: the production smoke makes zero live SerpApi calls, so it is deterministic and quota-free, while the agent/tile coverage remains via the mocked fast lane.
+
+## Architectural decisions
+
+- **Rely on the existing mocked fast-lane coverage rather than add a prod-reachable mock seam (chosen).** The production smoke runs against the live deployment, where SerpApi is called server-side; you cannot mock it from Playwright (browser-side) without reconstructing the SSE agent stream, and adding a production env flag or test-only endpoint that serves mock search data risks shipping fake data to real users. Since `chat-booking-flow.spec.ts` already exercises the tile flow deterministically under `E2E_MOCK_TOOLS`, the correct fix is to stop duplicating that flow against live quota, not to invent a prod mock path.
+- **Kept the production smoke driving real auth + persistence (not reverted to public-only).** Matches the intent that the smoke has grown beyond public pages; those paths are deterministic and cost nothing.
+
+## Testing
+
+- `e2e/production/smoke.spec.ts` retains all public-page and authenticated-reachability tests plus the (now search-free) persistence test; the only removed coverage (live tile rendering) is covered mocked in `chat-booking-flow.spec.ts`.
+- Lint: e2e specs are in the eslint ignore set; the fast lane (`e2e/`, separate testDir) is unaffected by this change to `e2e/production/`.
+- The live-prod smoke can only be exercised by the post-deploy workflow against the deployment; this change removes its dependency on live SerpApi.
+
+## Reflection
+
+The failing gate was not a code regression but a test-design problem: a per-deploy gate asserting on a live, paid, quota-limited dependency. The deterministic coverage already existed in the mock lane; the live duplicate only added flakiness and cost.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/e2e/production/smoke.spec.ts
+++ b/e2e/production/smoke.spec.ts
@@ -108,65 +108,11 @@ test.describe('authenticated smoke', () => {
     await logout(page);
   });
 
-  test('agent turn: trip creation and tile response', async ({ page }) => {
-    test.setTimeout(180_000);
-
-    await login(page, { email: SMOKE_EMAIL, password: SMOKE_PASSWORD });
-
-    const tripCreated = page.waitForResponse(
-      (res) =>
-        res.url().includes('/trips') &&
-        res.request().method() === 'POST' &&
-        res.status() === 201,
-      { timeout: 30_000 },
-    );
-    await page
-      .locator(
-        'a:has-text("New Trip"), button:has-text("New Trip"), a:has-text("New trip"), button:has-text("New trip")',
-      )
-      .first()
-      .click();
-    await tripCreated;
-    await expect(page).toHaveURL(
-      /\/trips\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/,
-      { timeout: 15_000 },
-    );
-
-    const input = page
-      .locator(
-        'input[aria-label="Ask the agent to plan your trip..."], input[placeholder="Ask the agent to plan your trip..."]',
-      )
-      .first();
-    await input.fill(
-      'Plan a 3-day trip to Lisbon, June 20 to June 23, for 2 people, budget $2000. Flights from JFK.',
-    );
-    await page
-      .locator('form')
-      .filter({ has: input })
-      .locator('button[type="submit"]')
-      .first()
-      .click();
-
-    const startPlanning = page
-      .locator('button:has-text("Start planning")')
-      .first();
-    try {
-      await startPlanning.waitFor({ state: 'visible', timeout: 45_000 });
-      await startPlanning.click();
-    } catch {
-      // Agent went straight to search without a plan-confirmation step.
-    }
-
-    const tileCard = page
-      .locator('[data-tile-card="flight"], [data-tile-card="hotel"]')
-      .first();
-    await expect(tileCard).toBeVisible({ timeout: 120_000 });
-
-    const ariaLabel = await tileCard.getAttribute('aria-label');
-    expect(ariaLabel).toBeTruthy();
-    expect(ariaLabel).not.toMatch(/undefined/i);
-    expect(ariaLabel).not.toMatch(/\bNaN\b/);
-  });
+  // The agent-turn tile-response assertion lives in the mocked e2e lane
+  // (chat-booking-flow.spec.ts US-22, E2E_MOCK_TOOLS=1), where flight/hotel
+  // tiles are deterministic. It is intentionally not duplicated here: against
+  // the live deployment it depended on real SerpApi results and burned the
+  // 250/month quota on every deploy, which is what made this gate flaky.
 
   test('trip persists across sessions: appears in list after navigation and reload', async ({
     page,
@@ -201,30 +147,10 @@ test.describe('authenticated smoke', () => {
       { timeout: 15_000 },
     );
 
-    // Send an initial message so the trip has a title/content
-    const input = page
-      .locator(
-        'input[aria-label="Ask the agent to plan your trip..."], input[placeholder="Ask the agent to plan your trip..."]',
-      )
-      .first();
-    await input.fill(
-      'Plan a 3-day trip to Barcelona, July 10 to July 13, for 2 people, budget $2500.',
-    );
-    await page
-      .locator('form')
-      .filter({ has: input })
-      .locator('button[type="submit"]')
-      .first()
-      .click();
-
-    // Wait for the agent to respond (at minimum, wait for the plan step)
-    await page
-      .locator('button:has-text("Start planning"), [data-tile-card]')
-      .first()
-      .waitFor({ state: 'visible', timeout: 120_000 })
-      .catch(() => {
-        // Agent may respond differently; continue regardless
-      });
+    // Persistence is established by trip creation (POST /trips) alone; the
+    // list assertion below keys off the created tripId. We intentionally do not
+    // send an agent message here, so this test does not drive a live SerpApi
+    // search (that path is covered, mocked, in the e2e fast lane).
 
     // Navigate to the trips list
     await page.goto('/trips');

--- a/playwright.production.config.ts
+++ b/playwright.production.config.ts
@@ -4,7 +4,10 @@ import path from 'node:path';
 /**
  * Production smoke config. Runs e2e/production/ specs against the live
  * deployment. No webServer block -- servers are already running.
- * Only covers public pages (no auth, no agent calls, zero API cost).
+ * Covers public pages plus authenticated reachability and trip persistence.
+ * It deliberately does NOT drive the agent's live search: agent and tile-card
+ * flows are exercised deterministically in the mocked e2e lane (E2E_MOCK_TOOLS),
+ * so the production smoke never depends on or consumes the live SerpApi quota.
  */
 
 const ROOT_DIR = __dirname;


### PR DESCRIPTION
**Closes #60.**

The Post-Deploy Health Check failed on every run for days: the `health-check` job passed, but `e2e-production` failed. Root cause: the production smoke's `agent turn: trip creation and tile response` test drove the agent against the **live** deployment and waited 120s for a real flight/hotel tile, which depends on live SerpApi (250 searches/month free tier, burned on every deploy). Flaky on quota/timing, not a code regression. It also violated the production config's own "public pages, no agent calls, zero API cost" contract.

## Change

- Removed the live-SerpApi `creation-and-tile-response` test. Its deterministic equivalent already runs **mocked** in the fast lane (`e2e/chat-booking-flow.spec.ts` US-22, `E2E_MOCK_TOOLS=1`), so the tile-card assertion is still covered against mocked SerpApi.
- Trimmed `trip persists across sessions` so it no longer sends an agent message (persistence keys off the created `tripId`; it never needed a live search).
- Updated the config doc: the production smoke has moved beyond public pages (now public, plus authenticated reachability and persistence) and deliberately does not drive live agent search.

Net effect: the production smoke makes zero live SerpApi calls (deterministic and quota-free), while agent/tile coverage stays in the mocked fast lane.

## Why not a prod mock seam

The smoke runs against live prod where SerpApi is called server-side; mocking it would require either a production env flag / test endpoint that risks serving fake data to real users, or reconstructing the SSE stream in Playwright. Relying on the existing mocked fast-lane coverage is the safer fix.

Full write-up: `docs/prs/2026-06-25-prod-smoke-mock-serpapi.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
