### PR TITLE
fix(#59): report deployed commit from RAILWAY_GIT_COMMIT_SHA

### DIFF
--- a/apps/server/src/__tests__/config/deployedCommit.test.ts
+++ b/apps/server/src/__tests__/config/deployedCommit.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readDeployedCommit } from 'app/config/deployedCommit.js';
+
+const SHA = '611902175a2e5c445a6d5f97fbadab93fa9878a2';
+
+let dir: string;
+let versionFile: string;
+const originalEnv = process.env.RAILWAY_GIT_COMMIT_SHA;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), 'deployed-commit-'));
+  versionFile = path.join(dir, 'version.json');
+  delete process.env.RAILWAY_GIT_COMMIT_SHA;
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  if (originalEnv === undefined) delete process.env.RAILWAY_GIT_COMMIT_SHA;
+  else process.env.RAILWAY_GIT_COMMIT_SHA = originalEnv;
+});
+
+describe('readDeployedCommit', () => {
+  it('prefers RAILWAY_GIT_COMMIT_SHA over the version file', () => {
+    process.env.RAILWAY_GIT_COMMIT_SHA = SHA;
+    writeFileSync(versionFile, JSON.stringify({ commit: 'stale-from-file' }));
+    expect(readDeployedCommit(versionFile)).toBe(SHA);
+  });
+
+  it('falls back to the version file when the env var is unset', () => {
+    writeFileSync(versionFile, JSON.stringify({ commit: SHA }));
+    expect(readDeployedCommit(versionFile)).toBe(SHA);
+  });
+
+  it('returns unknown when neither the env var nor the file is available', () => {
+    expect(readDeployedCommit(path.join(dir, 'missing.json'))).toBe('unknown');
+  });
+
+  it('returns unknown when the file has no commit field', () => {
+    writeFileSync(versionFile, JSON.stringify({}));
+    expect(readDeployedCommit(versionFile)).toBe('unknown');
+  });
+
+  it('ignores a blank env var and uses the file', () => {
+    process.env.RAILWAY_GIT_COMMIT_SHA = '   ';
+    writeFileSync(versionFile, JSON.stringify({ commit: SHA }));
+    expect(readDeployedCommit(versionFile)).toBe(SHA);
+  });
+});

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -18,6 +18,7 @@ import {
 import { logger } from 'app/clients/logger.js';
 import { posthog } from 'app/clients/posthog.js';
 import { corsConfig } from 'app/config/corsConfig.js';
+import { readDeployedCommit } from 'app/config/deployedCommit.js';
 import { env, validateProductionEnv } from 'app/config/env.js';
 import { pool, query } from 'app/database/pool.js';
 import { getSharedTripHandler } from 'app/handlers/trips/share.js';
@@ -35,18 +36,11 @@ import { tripRouter } from 'app/routes/trips.js';
 import { userPreferencesRouter } from 'app/routes/userPreferences.js';
 
 function readCommitSha(): string {
-  try {
-    const versionPath = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
-      'data/version.json',
-    );
-    const { commit } = JSON.parse(fs.readFileSync(versionPath, 'utf-8')) as {
-      commit: string;
-    };
-    return commit || 'unknown';
-  } catch {
-    return 'unknown';
-  }
+  const versionPath = path.resolve(
+    path.dirname(new URL(import.meta.url).pathname),
+    'data/version.json',
+  );
+  return readDeployedCommit(versionPath);
 }
 
 function validateEnv(): void {

--- a/apps/server/src/config/deployedCommit.ts
+++ b/apps/server/src/config/deployedCommit.ts
@@ -1,0 +1,29 @@
+/**
+ * Resolves the deployed commit SHA reported by /health. Prefers Railway's
+ * injected RAILWAY_GIT_COMMIT_SHA, which is set on every git-sourced deploy with
+ * no build or pre-deploy step required, so the reported commit is correct
+ * regardless of how the deploy was triggered. Falls back to the version.json
+ * stamp written by scripts/deploy.sh (for manual `railway up`), then 'unknown'.
+ * Issue #59: a raw `railway up` left version.json stale and /health reported the
+ * wrong commit; preferring the env var removes that dependency.
+ */
+import fs from 'node:fs';
+
+const UNKNOWN_COMMIT = 'unknown';
+
+export function readDeployedCommit(versionFilePath: string): string {
+  const fromEnv = process.env.RAILWAY_GIT_COMMIT_SHA?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  try {
+    const { commit } = JSON.parse(
+      fs.readFileSync(versionFilePath, 'utf-8'),
+    ) as {
+      commit?: string;
+    };
+    return commit || UNKNOWN_COMMIT;
+  } catch {
+    return UNKNOWN_COMMIT;
+  }
+}

--- a/docs/prs/2026-06-24-deploy-commit-stamp.md
+++ b/docs/prs/2026-06-24-deploy-commit-stamp.md
@@ -1,0 +1,31 @@
+# Report deployed commit from RAILWAY_GIT_COMMIT_SHA (#59)
+
+**Date:** 2026-06-24
+**Branch:** `fix/deploy-commit-stamp`
+**Closes:** #59
+
+## Summary
+
+`/health/ready` reports the deployed commit so a deploy can be verified. That value came solely from `apps/server/src/data/version.json`, which only `scripts/deploy.sh` writes (it stamps `git rev-parse HEAD` before `railway up`). Any deploy path that bypasses the script left a stale stamp. This was hit during the 2026-06-24 production deploy: a raw `railway up` shipped the new code but `/health` kept reporting the previous commit until `deploy.sh` was re-run, which silently breaks deploy verification.
+
+## What changed
+
+- New `apps/server/src/config/deployedCommit.ts` exporting `readDeployedCommit(versionFilePath)`: prefers `process.env.RAILWAY_GIT_COMMIT_SHA` (injected by Railway on every git-sourced deploy, no build/pre-deploy step needed), falls back to the `version.json` stamp for manual `railway up` via `deploy.sh`, then `'unknown'`.
+- `app.ts` `readCommitSha()` now delegates to it (removing the inline file read).
+- Unit tests cover env-var precedence, file fallback, missing file, missing `commit` field, and blank env var.
+
+## Architectural decisions
+
+- **Prefer the platform env var over a pre-deploy stamp (chosen) vs. only fixing `deploy.sh` (alternative).** Keying off `RAILWAY_GIT_COMMIT_SHA` makes the reported commit correct without depending on a human running the right script, so the git-sourced web service and any future git-triggered deploy report accurately by default. `version.json` remains as the fallback for the manual upload path, so nothing regresses.
+- **Inject the version-file path as a parameter (chosen) vs. resolving it inside the function.** Keeps the resolver pure and unit-testable against a temp file; `app.ts` owns the path resolution.
+
+## Testing
+
+- `deployedCommit.test.ts`: 5 cases, all green. `tsc --noEmit` clean.
+- Note: this does not fully cover a raw `railway up` with no git env var set (still falls back to whatever `version.json` holds); the durable fix for that path is the documented `scripts/deploy.sh`. The env-var preference removes the dependency for every git-sourced deploy.
+
+## Reflection
+
+The bug surfaced from operator error (I deployed with raw `railway up` instead of `deploy.sh`), but the real fault is that the commit stamp depended on a side effect of one script. Sourcing it from the platform-provided env var makes the common path self-correcting.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
**Closes #59.**

`/health/ready` reports the deployed commit so a deploy can be verified, but that value came solely from `apps/server/src/data/version.json`, which only `scripts/deploy.sh` writes (it stamps `git rev-parse HEAD` before `railway up`). Any deploy path that bypasses the script left a stale stamp. Hit during the 2026-06-24 production deploy: a raw `railway up` shipped new code but `/health` kept reporting the previous commit until `deploy.sh` was re-run, silently breaking deploy verification.

## Change

- New `apps/server/src/config/deployedCommit.ts` (`readDeployedCommit(versionFilePath)`): prefers `process.env.RAILWAY_GIT_COMMIT_SHA` (injected by Railway on every git-sourced deploy, no build step needed), falls back to the `version.json` stamp for manual `railway up`, then `'unknown'`.
- `app.ts` `readCommitSha()` delegates to it.
- Unit tests: env-var precedence, file fallback, missing file, missing `commit` field, blank env var (5 cases).

## Decisions

- Prefer the platform env var over only fixing `deploy.sh`, so the reported commit is correct without depending on a human running the right script. `version.json` stays as the fallback, so nothing regresses.
- Inject the version-file path as a parameter to keep the resolver pure and unit-testable.

Full write-up: `docs/prs/2026-06-24-deploy-commit-stamp.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
